### PR TITLE
Feature/no more timeouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7294,9 +7294,9 @@
       "dev": true
     },
     "message-event-channel": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/message-event-channel/-/message-event-channel-1.0.1.tgz",
-      "integrity": "sha512-68T7Xvp1y/m1bZMhj5HxM9kcUkbbbvoUeiPmORWKsJe1ozdM6wlcwpLDfFRo4XlICd+EbXCV41Gob32dsU5o5A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/message-event-channel/-/message-event-channel-1.1.0.tgz",
+      "integrity": "sha512-/6tBIQr8xmGiTkQZbLwiIxdsG21VcykYryk08cEdJdphEPYYCwi9ur/jSDfbQ6fY1urqo8TDZQ7dr7xJOrCqqw==",
       "requires": {
         "url-polyfill": "^1.1.7"
       }
@@ -14614,9 +14614,9 @@
       }
     },
     "url-polyfill": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
-      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.8.tgz",
+      "integrity": "sha512-Ey61F4FEqhcu1vHSOMmjl0Vd/RPRLEjMj402qszD/dhMBrVfoUsnIj8KSZo2yj+eIlxJGKFdnm6ES+7UzMgZ3Q=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "message-event-channel": "^1.0.1"
+    "message-event-channel": "github:amplience/message-event-channel#feature/teardown-behaviour"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     ]
   },
   "dependencies": {
-    "message-event-channel": "github:amplience/message-event-channel#feature/teardown-behaviour"
+    "message-event-channel": "^1.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.3",

--- a/src/lib/SDK.ts
+++ b/src/lib/SDK.ts
@@ -16,12 +16,14 @@ export interface IClientConnection extends ClientConnection {}
  */
 export interface OptionsObject {
   window?: Window;
-  connectionTimeout?: number;
+  connectionTimeout?: number | boolean;
+  timeout?: number | boolean;
   debug?: boolean;
 }
 export interface Options {
   window: Window;
-  connectionTimeout: number;
+  connectionTimeout: number | boolean;
+  timeout: number | boolean;
   debug: boolean;
 }
 export interface Params {
@@ -91,7 +93,8 @@ export class SDK<FieldType = any, ParamType extends Params = Params> {
   protected options: Options;
   protected readonly defaultOptions: Options = {
     window: window,
-    connectionTimeout: 4500,
+    connectionTimeout: false,
+    timeout: false,
     debug: false
   };
 

--- a/test/Frame.spec.ts
+++ b/test/Frame.spec.ts
@@ -126,8 +126,9 @@ describe('Frame', () => {
   });
 
   describe('Frame.startAutoResizer()', () => {
-    xit('should start auto resizer', done => {
+    it('should start auto resizer', done => {
       const frame: Frame = new Frame(connection);
+      body.style.height = '0px';
       const emitSpy = spyOn(connection, 'emit');
       frame.startAutoResizer();
       body.style.height = '100px';

--- a/test/Init.spec.ts
+++ b/test/Init.spec.ts
@@ -8,17 +8,17 @@ describe('init', () => {
 
   it('should reject the promise when it times out', async done => {
     try {
-      await init();
+      await init({ connectionTimeout: 1 });
     } catch (e) {
       expect(e.message).toEqual('Failed to establish connection to DC Application');
       done();
     }
   });
 
-  it('should beable to accept options', async done => {
+  it('should be able to accept options', async done => {
     try {
       spyOn(console, 'log');
-      await init({ debug: true });
+      await init({ debug: true, connectionTimeout: 1 });
       expect(console.log).toHaveBeenCalled();
     } catch (e) {
       expect(e.message).toEqual('Failed to establish connection to DC Application');

--- a/test/SDK.spec.ts
+++ b/test/SDK.spec.ts
@@ -23,7 +23,7 @@ describe('SDK', () => {
   });
 
   it('init() should reject the promise when it times out', async done => {
-    const sdk = new SDK();
+    const sdk = new SDK({ connectionTimeout: 1 });
     try {
       await sdk.init();
     } catch (e) {


### PR DESCRIPTION
* Making options the same as the message-event-channel lib
* Removed timeouts by default
* Fixed existing flaky test