### PR TITLE
feat(context): making category mandatory for content field

### DIFF
--- a/src/lib/extensions/Extension.ts
+++ b/src/lib/extensions/Extension.ts
@@ -8,6 +8,7 @@ export interface ExtensionOptions extends InitOptions {
 }
 
 export interface ContextObject {
+  category: string;
   params: Params;
 }
 

--- a/src/lib/extensions/ExtensionFactory.spec.ts
+++ b/src/lib/extensions/ExtensionFactory.spec.ts
@@ -13,6 +13,7 @@ describe('ExtensionFactory', () => {
     };
     const connection = new ClientConnection(options);
     const context = {
+      category: 'CONTENT_FIELD',
       contentItemId: '12345678-abcd-1234-1234-abcdef123456',
       fieldSchema: {
         title: 'test-field-schema-title',

--- a/src/lib/extensions/content-field/ContentFieldContextObject.spec.ts
+++ b/src/lib/extensions/content-field/ContentFieldContextObject.spec.ts
@@ -4,6 +4,7 @@ describe('ContentFieldContextObject', () => {
   describe('isContentFieldContextObject', () => {
     it('should return true with a valid content field context', () => {
       const context = {
+        category: 'CONTENT_FIELD',
         contentItemId: '12345678-abcd-1234-1234-abcdef123456',
         fieldSchema: {
           title: 'test-field-schema-title',

--- a/src/lib/extensions/content-field/ContentFieldContextObject.ts
+++ b/src/lib/extensions/content-field/ContentFieldContextObject.ts
@@ -19,6 +19,7 @@ export function isContentFieldContextObject(
 ): context is ContentFieldContextObject {
   return (
     isContextObject(context) &&
+    (context as ContentFieldContextObject).category === 'CONTENT_FIELD' &&
     (context as ContentFieldContextObject)?.params?.instance !== undefined &&
     (context as ContentFieldContextObject).contentItemId !== undefined &&
     (context as ContentFieldContextObject).fieldSchema !== undefined &&

--- a/src/lib/extensions/content-field/ContentFieldExtension.spec.ts
+++ b/src/lib/extensions/content-field/ContentFieldExtension.spec.ts
@@ -31,6 +31,7 @@ describe('ContentFieldExtension', () => {
         debug: false,
       };
       const context = {
+        category: 'CONTENT_FIELD',
         contentItemId: '12345678-abcd-1234-1234-abcdef123456',
         fieldSchema: {
           title: 'test-field-schema-title',

--- a/src/lib/extensions/dashboard/DashboardContextObject.ts
+++ b/src/lib/extensions/dashboard/DashboardContextObject.ts
@@ -2,7 +2,6 @@ import { Params } from '../../models/Params';
 import { ContextObject, isContextObject } from '../Extension';
 
 export interface DashboardContextObject<ParamType extends Params = Params> extends ContextObject {
-  category: string;
   hubId: string;
   locationHref: string;
   params: ParamType;


### PR DESCRIPTION
The dc-app is being updated to pass `category` in the context for content fields.   This update allows the context factory to determine the context more specifically using the category.