### PR TITLE
build(github actions): automation for gh pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,20 @@ jobs:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm ci
+      - run: |
+          npm ci
+          npm test
+          npm run build
         if: ${{ steps.release.outputs.release_created }}
 
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}
+        
+      - name: Deploy docs 🚀
+        uses: JamesIves/github-pages-deploy-action@93065a8b71cd5d57c379528f7a43a2e38d908af0
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          branch: gh-pages
+          folder: docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,7 @@ Keep in mind that after running `npm install` the git repo is reset. So a good w
 Make and commit your changes. Make sure the commands npm run build and npm run test:prod are working.
 
 Finally send a [GitHub Pull Request](https://github.com/alexjoverm/typescript-library-starter/compare?expand=1) with a clear list of what you've done (read more [about pull requests](https://help.github.com/articles/about-pull-requests/)). Make sure all of your commits are atomic (one feature per commit).
+
+## Release
+
+This repository uses Github Actions to manage releases. To create a release, merge your approved PR into the master branch. This will then create a release PR which needs to be approved before it can be merged. This PR will include the bunped version and update the changelog. Once merged, Github Actions will automatically build, test, and publish the release as well as deploy the documentation [gh-page](https://amplience.github.io/dc-extensions-sdk/).


### PR DESCRIPTION
Not sure what happened here but this [merge](https://github.com/amplience/dc-extensions-sdk/pull/61) somehow didn't? 